### PR TITLE
Remove left over containers

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,8 +2,9 @@
 
 set -ex
 
+docker rm luet || true
 docker run --name luet quay.io/luet/base:"$LUET_TAG" && docker cp luet:/usr/bin/luet ./
-docker rm luet
+docker rm luet || true
 chmod +x luet
 sudo mv luet /usr/bin/luet
 sudo mkdir -p /etc/luet/repos.conf.d/

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 set -ex
 
 docker run --name luet quay.io/luet/base:"$LUET_TAG" && docker cp luet:/usr/bin/luet ./
+docker rm luet
 chmod +x luet
 sudo mv luet /usr/bin/luet
 sudo mkdir -p /etc/luet/repos.conf.d/


### PR DESCRIPTION
because next run will complain when using non-volatile runners
